### PR TITLE
Add fixture that enables custom components in test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,12 @@ import pytest
 pytest_plugins = "pytest_homeassistant_custom_component"
 
 
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations"""
+    yield
+
+
 # This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
 # notifications. These calls would fail without this fixture since the persistent_notification
 # integration is never loaded during a test.


### PR DESCRIPTION
Apparently this is needed due to changes in homeassistant. Details:
https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/70