### PR TITLE
Use old pip version and don't bump with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,11 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "pip"
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "pip"

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,4 @@
-pip==21.1.1
+pip>=8.0.3,<20.3 # from home assistant
 pre-commit==2.13.0
 black==21.4b2
 flake8==3.9.2


### PR DESCRIPTION
Home assistant requires pip<20.3, so there's no point in installing newer versions.