### PR TITLE
edits only from custom_components

### DIFF
--- a/custom_components/egauge/__init__.py
+++ b/custom_components/egauge/__init__.py
@@ -6,41 +6,43 @@ https://github.com/neggert/egauge
 """
 import logging
 from datetime import timedelta
+from typing import override
 
 import homeassistant.util.dt as dt_util
-from egauge_async import EgaugeClient
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.helpers.update_coordinator import UpdateFailed
+from egauge_async import EgaugeClient, data_models
+from homeassistant import config_entries, core, exceptions
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_EGAUGE_URL
-from .const import CONF_PASSWORD
-from .const import CONF_USERNAME
-from .const import DAILY
-from .const import DOMAIN
-from .const import EGAUGE_HISTORICAL
-from .const import EGAUGE_INSTANTANEOUS
-from .const import MONTHLY
-from .const import SENSOR
-from .const import STARTUP_MESSAGE
-from .const import TODAY
-from .const import WEEKLY
-from .const import YEARLY
+from .const import (
+    CONF_EGAUGE_URL,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DAILY,
+    DOMAIN,
+    EGAUGE_HISTORICAL,
+    EGAUGE_INSTANTANEOUS,
+    MONTHLY,
+    SENSOR,
+    STARTUP_MESSAGE,
+    TODAY,
+    WEEKLY,
+    YEARLY,
+)
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
-    """Set up this integration using YAML is not supported."""
+async def async_setup(hass: core.HomeAssistant, config: dict) -> bool:  # noqa: ARG001
+    """Set up the eGauge Power Meter component."""
+    # @TODO: Add setup code.
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+) -> bool:
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})
@@ -58,11 +60,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_refresh()
 
     if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+        raise exceptions.ConfigEntryNotReady
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, SENSOR))
+    await hass.config_entries.async_forward_entry_setups(entry, [SENSOR])
 
     entry.add_update_listener(async_reload_entry)
     return True
@@ -73,7 +75,7 @@ class EGaugeDataUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(
         self,
-        hass: HomeAssistant,
+        hass: core.HomeAssistant,
         client: EgaugeClient,
         update_interval: timedelta,
     ) -> None:
@@ -81,7 +83,8 @@ class EGaugeDataUpdateCoordinator(DataUpdateCoordinator):
         self.client = client
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)
 
-    async def _async_update_data(self):
+    @override
+    async def _async_update_data(self):  # noqa: ANN202
         """Update data via library."""
         try:
             current_rates = await self.client.get_current_rates()
@@ -96,10 +99,10 @@ class EGaugeDataUpdateCoordinator(DataUpdateCoordinator):
                 now - timedelta(days=30),
                 now - timedelta(days=365),
             ]
-            _LOGGER.debug(f"Querying eGauge for timestamps {timestamps}")
+            _LOGGER.debug("Querying eGauge for timestamps %s", timestamps)
 
             data = await self.client.get_historical_data(timestamps=timestamps)
-            _LOGGER.debug(f"eGauge responded with {data}")
+            _LOGGER.debug("eGauge responded with %s", data)
 
             historical_data = {
                 TODAY: self._compute_register_diffs(data[1], data[0]),
@@ -108,22 +111,27 @@ class EGaugeDataUpdateCoordinator(DataUpdateCoordinator):
                 MONTHLY: self._compute_register_diffs(data[4], data[0]),
                 YEARLY: self._compute_register_diffs(data[5], data[0]),
             }
+        except Exception as exception:
+            _LOGGER.warning("Exception fetching eGauge data: %s", exception)
+            raise UpdateFailed from exception
+        else:
             return {
                 EGAUGE_INSTANTANEOUS: current_rates,
                 EGAUGE_HISTORICAL: historical_data,
             }
-        except Exception as exception:
-            _LOGGER.warning(f"Exception fetching eGauge data: {exception}")
-            raise UpdateFailed() from exception
 
-    def _compute_register_diffs(self, start, end):
+    def _compute_register_diffs(
+        self, start: data_models.DataRow, end: data_models.DataRow
+    ) -> dict[str, int]:
+        # each of these is a dict[str, int]
         start_vals = {k: r.value for k, r in start.registers.items()}
         end_vals = {k: r.value for k, r in end.registers.items()}
-        diff = {k: end_vals[k] - start_vals[k] for k in end_vals.keys()}
-        return diff
+        return {k: end_vals[k] - start_vals[k] for k in end_vals}
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+) -> bool:
     """Handle removal of an entry."""
     unloaded = await hass.config_entries.async_forward_entry_unload(entry, SENSOR)
     if unloaded:
@@ -133,7 +141,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unloaded
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)

--- a/custom_components/egauge/config_flow.py
+++ b/custom_components/egauge/config_flow.py
@@ -1,12 +1,12 @@
 """Adds config flow for eGauge."""
+from typing import Any
+
 import voluptuous as vol
 from egauge_async import EgaugeClient
 from homeassistant import config_entries
 
-from .const import CONF_EGAUGE_URL
-from .const import CONF_PASSWORD
-from .const import CONF_USERNAME
-from .const import DOMAIN
+from . import _LOGGER
+from .const import CONF_EGAUGE_URL, CONF_PASSWORD, CONF_USERNAME, DOMAIN
 
 
 class EGaugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -15,11 +15,11 @@ class EGaugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize."""
         self._errors = {}
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle a flow initialized by the user."""
         self._errors = {}
 
@@ -33,14 +33,16 @@ class EGaugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=user_input[CONF_EGAUGE_URL], data=user_input
                 )
-            else:
-                self._errors["base"] = "auth"
 
+            self._errors["base"] = "auth"
             return await self._show_config_form(user_input)
 
         return await self._show_config_form(user_input)
 
-    async def _show_config_form(self, user_input):  # pylint: disable=unused-argument
+    async def _show_config_form(
+        self,
+        user_input: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> config_entries.ConfigFlowResult:
         """Show the configuration form to edit location data."""
         return self.async_show_form(
             step_id="user",
@@ -56,13 +58,14 @@ class EGaugeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def _test_credentials(self, url, username, password):
+    async def _test_credentials(self, url: str, username: str, password: str) -> bool:
         """Return true if credentials is valid."""
         try:
             client = EgaugeClient(url, username, password)
             await client.get_instantaneous_registers()
             await client.close()
+        except Exception:  # noqa: BLE001
+            _LOGGER.info("credentials did not validate")
+        else:
             return True
-        except Exception:  # pylint: disable=broad-except
-            pass
         return False

--- a/custom_components/egauge/const.py
+++ b/custom_components/egauge/const.py
@@ -1,23 +1,19 @@
 """Constants for eGauge."""
-from homeassistant.const import DEVICE_CLASS_CURRENT
-from homeassistant.const import DEVICE_CLASS_ENERGY
-from homeassistant.const import DEVICE_CLASS_HUMIDITY
-from homeassistant.const import DEVICE_CLASS_POWER
-from homeassistant.const import DEVICE_CLASS_PRESSURE
-from homeassistant.const import DEVICE_CLASS_TEMPERATURE
-from homeassistant.const import DEVICE_CLASS_VOLTAGE
-from homeassistant.const import ELECTRIC_CURRENT_AMPERE
-from homeassistant.const import ELECTRIC_POTENTIAL_VOLT
-from homeassistant.const import ENERGY_KILO_WATT_HOUR
-from homeassistant.const import PERCENTAGE
-from homeassistant.const import POWER_WATT
-from homeassistant.const import PRESSURE_PA
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.components.sensor.const import SensorDeviceClass
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfPressure,
+    UnitOfTemperature,
+)
 
 # Base component constants
+DOMAIN = "egauge"
 NAME = "eGauge"
 MODEL = "XML API"
-DOMAIN = "egauge"
 DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.0.0"
 
@@ -29,7 +25,7 @@ SENSOR = "sensor"
 # Configuration and options
 CONF_ENABLED = "enabled"
 CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
+CONF_PASSWORD = "password"  # noqa: S105
 CONF_EGAUGE_URL = "egauge_url"
 
 # Defaults
@@ -42,29 +38,29 @@ EGAUGE_TODAY = "today"
 # Device Classes by eGauge Register Type Code
 EGAUGE_DEVICE_CLASS = {
     EGAUGE_INSTANTANEOUS: {
-        "h": DEVICE_CLASS_HUMIDITY,
-        "T": DEVICE_CLASS_TEMPERATURE,
-        "P": DEVICE_CLASS_POWER,
-        "Pa": DEVICE_CLASS_PRESSURE,
-        "I": DEVICE_CLASS_CURRENT,
-        "V": DEVICE_CLASS_VOLTAGE,
+        "h": SensorDeviceClass.HUMIDITY,
+        "T": SensorDeviceClass.TEMPERATURE,
+        "P": SensorDeviceClass.POWER,
+        "Pa": SensorDeviceClass.PRESSURE,
+        "I": SensorDeviceClass.CURRENT,
+        "V": SensorDeviceClass.VOLTAGE,
     },
     EGAUGE_HISTORICAL: {
-        "P": DEVICE_CLASS_ENERGY,
+        "P": SensorDeviceClass.ENERGY,
     },
 }
 
 EGAUGE_UNITS = {
     EGAUGE_INSTANTANEOUS: {
         "h": PERCENTAGE,
-        "T": TEMP_CELSIUS,
-        "P": POWER_WATT,
-        "Pa": PRESSURE_PA,
-        "I": ELECTRIC_CURRENT_AMPERE,
-        "V": ELECTRIC_POTENTIAL_VOLT,
+        "T": UnitOfTemperature.CELSIUS,
+        "P": UnitOfPower.WATT,
+        "Pa": UnitOfPressure.PA,
+        "I": UnitOfElectricCurrent.AMPERE,
+        "V": UnitOfElectricPotential.VOLT,
     },
     EGAUGE_HISTORICAL: {
-        "P": ENERGY_KILO_WATT_HOUR,
+        "P": UnitOfEnergy.KILO_WATT_HOUR,
     },
 }
 

--- a/custom_components/egauge/entity.py
+++ b/custom_components/egauge/entity.py
@@ -1,13 +1,14 @@
-"""EGaugeEntity class"""
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+"""Representation of an eGauge entity."""
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    _DataUpdateCoordinatorT,
+)
 
-from .const import DOMAIN
-from .const import MODEL
-from .const import NAME
+from .const import DOMAIN, MODEL, NAME
 
 
 class EGaugeEntity(CoordinatorEntity):
-    def __init__(self, coordinator, config_entry):
+    def __init__(self, coordinator: _DataUpdateCoordinatorT, config_entry):
         super().__init__(coordinator)
         self.config_entry = config_entry
         self.entry_id = self.config_entry.entry_id

--- a/custom_components/egauge/sensor.py
+++ b/custom_components/egauge/sensor.py
@@ -118,6 +118,17 @@ class EGaugeSensor(EGaugeEntity, SensorEntity):
             data = data[self.interval]
         value = data.get(self.register_name)
         value = value * self.unit_conversion
+        if self.state_class == SensorStateClass.TOTAL_INCREASING and value < 0:
+            pv = value
+            value = abs(value)
+            _LOGGER.debug(
+                "%s is total_increasing: %s -> %s (%s)",
+                self.name,
+                pv,
+                value,
+                f"{value:.2f}",
+            )
+
         return f"{value:.2f}"
 
     @property


### PR DESCRIPTION
I consolidated all edits from `custom_components` into these commits in my master branch.

Most everything is inside one 'squashed' commit inside this PR, but I did call out one change in a separate commit where hass was giving warnings regarding TOTAL_INCREASING sensor types that sometimes took on negative values. I got rid of the warning by returning the absolute value of the sensor in those cases, but that's likely a hack as I wasn't sure about the real underlying issue. That change is in sensor.py, line 121.