### PR TITLE
Switch "today" sensor type to TOTAL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,4 +45,4 @@ branch = False
 
 [coverage:report]
 show_missing = true
-fail_under = 95
+fail_under = 100

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -26,12 +26,13 @@ async def test_instantaneous_sensor_creation(
 ):
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
 
-    with patch(
-        "egauge_async.EgaugeClient.get_instantaneous_registers"
-    ) as get_registers, patch(
-        "custom_components.egauge.EGaugeDataUpdateCoordinator._async_update_data",
-        new_callable=AsyncMock,
-    ) as update:
+    with (
+        patch("egauge_async.EgaugeClient.get_instantaneous_registers") as get_registers,
+        patch(
+            "custom_components.egauge.EGaugeDataUpdateCoordinator._async_update_data",
+            new_callable=AsyncMock,
+        ) as update,
+    ):
         get_registers.return_value = {"power_register": "P"}
         update.return_value = {EGAUGE_INSTANTANEOUS: {"power_register": 1234}}
         config_entry.add_to_hass(hass)
@@ -64,14 +65,14 @@ async def test_historical_sensor_creation(
 ):
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
 
-    with patch(
-        "egauge_async.EgaugeClient.get_historical_registers"
-    ) as get_registers, patch(
-        "custom_components.egauge.EGaugeDataUpdateCoordinator._async_update_data",
-        new_callable=AsyncMock,
-    ) as update, patch(
-        "homeassistant.util.dt.start_of_local_day"
-    ) as start_of_day:
+    with (
+        patch("egauge_async.EgaugeClient.get_historical_registers") as get_registers,
+        patch(
+            "custom_components.egauge.EGaugeDataUpdateCoordinator._async_update_data",
+            new_callable=AsyncMock,
+        ) as update,
+        patch("homeassistant.util.dt.start_of_local_day") as start_of_day,
+    ):
         get_registers.return_value = {"power_register": "P"}
         update.return_value = {
             EGAUGE_HISTORICAL: {
@@ -116,7 +117,8 @@ async def test_historical_sensor_creation(
             "register_type_code": "P",
             "data_type": EGAUGE_HISTORICAL,
             "device_class": "energy",
-            "state_class": "total_increasing",
+            "state_class": "total",
+            "last_reset": "2020-01-01T00:00:00",
             "friendly_name": "egauge todays power_register",
             "unit_of_measurement": "kWh",
             "icon": "hass:flash",


### PR DESCRIPTION
Currently, the `todays_*` sensors have sensor type `TOTAL_INCREASING`. However, some eGauge setups have sensors that intentionally report negative values. These didn't work correctly and spammed logs with warnings similar to

> egauge todays Sensor 2 is total_increasing yet value is negative (-3.317182222222222); setting to zero

Home assistant [now supports](https://developers.home-assistant.io/blog/2021/09/20/state_class_total/) a `TOTAL` sensor type that supports sensors with both positive and negative values. Unlike `TOTAL_INCREASING`, it requires setting the `last_reset` attribute, but that's not a problem. For `todays_*` sensors, that value is always the start of the local day. We explicitly pass this timestamp to the eGauge API in order to calculate today's change.