### PR TITLE
Fix loading error in HA 2025.2

### DIFF
--- a/custom_components/egauge/const.py
+++ b/custom_components/egauge/const.py
@@ -16,7 +16,7 @@ DOMAIN = "egauge"
 NAME = "eGauge"
 MODEL = "XML API"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.0.0"
+VERSION = "0.5.1"
 
 ISSUE_URL = "https://github.com/neggert/egauge/issues"
 

--- a/custom_components/egauge/entity.py
+++ b/custom_components/egauge/entity.py
@@ -2,14 +2,14 @@
 
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
-    _DataUpdateCoordinatorT,
+    DataUpdateCoordinator,
 )
 
 from .const import DOMAIN, MODEL, NAME
 
 
 class EGaugeEntity(CoordinatorEntity):
-    def __init__(self, coordinator: _DataUpdateCoordinatorT, config_entry):
+    def __init__(self, coordinator: DataUpdateCoordinator, config_entry):
         super().__init__(coordinator)
         self.config_entry = config_entry
         self.entry_id = self.config_entry.entry_id

--- a/custom_components/egauge/manifest.json
+++ b/custom_components/egauge/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/neggert/hass-egauge/issues",
   "requirements": ["egauge-async==0.1.2"],
-  "version": "0.4.1"
+  "version": "0.5.1"
 }


### PR DESCRIPTION
Loading error in HA 2025.2 (https://github.com/neggert/hass-egauge/issues/330) seem to be caused by the use of the `_DataUpdateCoordinatorT` class, which I think is internal, so a breaking change wouldn't be shown there. Comparing to some other recently updated components, using `DataUpdateCoordinator` seems to be the better choice, and it does work, and the component loads successfully in 2025.2.0.

I've also incremented version numbers to support the next release (0.5.0 was ambiguously numbered - release shows 0.5.0, but HA still shows 0.4.1).